### PR TITLE
[fix] 监听器的onDownloadStart未触发

### DIFF
--- a/downloader/src/main/java/com/chiclaim/android/downloader/EmbedDownloader.kt
+++ b/downloader/src/main/java/com/chiclaim/android/downloader/EmbedDownloader.kt
@@ -206,6 +206,7 @@ class EmbedDownloader(request: DownloadRequest) :
 
 
     override fun download() {
+        super.download()
         DownloadExecutor.execute {
             var url: URL? = null
             var conn: HttpURLConnection? = null


### PR DESCRIPTION
[fix] 在embed引擎下，EmbedDownloader的download()未调用父类的download()，最终导致监听器的onDownloadStart未触发